### PR TITLE
remove ExpressionTreeForge from unregistered dependencies (gh-actions)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,14 +14,6 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.7'
-      - name: Installing non-registered dependencies
-        run: |
-          using Pkg
-          pkg1 = PackageSpec(url = "https://github.com/JuliaSmoothOptimizers/ExpressionTreeForge.jl.git")
-          pkg2 = PackageSpec(url = "https://github.com/JuliaSmoothOptimizers/PartiallySeparableNLPModels.jl.git")
-          pkg_list = [pkg1, pkg2]
-          Pkg.add(pkg_list)
-        shell: julia --project=docs --color=yes {0}
       - name: Install dependencies
         run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,6 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - name: Installing non-registered dependencies
-        run: |
-          using Pkg
-          pkg1 = PackageSpec(url = "https://github.com/JuliaSmoothOptimizers/ExpressionTreeForge.jl.git")
-          pkg_list = [pkg1]
-          Pkg.add(pkg_list)
-        shell: julia --project=@. --color=yes {0}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
The script for unregistered dependencies uses gh/ETF.jl.git to load ETF in the julia environnement.
It provokes errors related to the depencies versions use in unit tests.

When there will be ETF v0.1.3, I will update the dependencies of this module.