### PR TITLE
Fix a corner case during the distinction of element expression trees

### DIFF
--- a/src/partitionedNLPModels/utils.jl
+++ b/src/partitionedNLPModels/utils.jl
@@ -29,7 +29,7 @@ function distinct_element_expr_tree(
   # evaluate every element functions to reduce the number of comparisons between element expression trees
   vec_val_elt_fun = map(
     (elt_fun, elt_vars) ->
-      ExpressionTreeForge.evaluate_expr_tree(elt_fun, Float64[1:length(elt_vars);]),
+      ExpressionTreeForge.evaluate_expr_tree(elt_fun, collect(Float64,1:length(elt_vars))),
     vec_element_expr_tree,
     vec_element_variables,
   )


### PR DESCRIPTION
Fix a corner case happening during the distinction of element expression trees:

Example:
Suppose the function `f`
```julia
f(x) = (x[1] + x[2])/x[1] + (x[2] + x[3])/x[1]
element_variables = [[1,2], [1,2,3]]
```
where `f1 = (x[1] + x[2])/x[1]` and `f2 = (x[2] + x[3])/x[1]`.
In order to avoid the comparison between every pair of element expression trees, I implemented an heuristic evaluating every element expression tree using a generic vector `x = ones(length(element_variables))`.
Even if `length(element_variables[1]) == 2` is different from `length(element_variables[3]) == 3`, the evaluation of `f1(x)` was equal to `f2(x)`.
This heuristic was completed by an evaluation between the expression trees having the same value.
And since the `==` method from ExpressionTreeForge.jl was incorrect (fixed by this [PR](https://github.com/JuliaSmoothOptimizers/ExpressionTreeForge.jl/pull/49)) my code was recognizing `f1` and `f2` as the same element expression tree.

As a consequently, an error orccured because the partitioned structures were not defined properly.