### PR TITLE
Fix a corner case of `grad`

### DIFF
--- a/src/partitionedNLPModels/utils.jl
+++ b/src/partitionedNLPModels/utils.jl
@@ -83,6 +83,8 @@ function distinct_element_expr_tree(
   return element_expr_trees, indices_element_tree
 end
 
+find_ni(element_variables::Vector{Int}) = isempty(element_variables) ? 0 : maximum(element_variables)
+
 """
     element_gradient_tape = compiled_grad_element_function(element_function::T; ni::Int = length(ExpressionTreeForge.get_elemental_variables(element_function)), type = Float64) where {T}
 
@@ -91,7 +93,7 @@ Return the `elment_gradient_tape::GradientTape` which speed up the gradient comp
 function compiled_grad_element_function(
   element_function::T;
   element_variables::Vector{Int}=ExpressionTreeForge.get_elemental_variables(element_function),
-  ni::Int = maximum(element_variables),  
+  ni::Int = find_ni(element_variables),
   type = Float64,
 ) where {T}  
   f = ExpressionTreeForge.evaluate_expr_tree(element_function)
@@ -166,7 +168,7 @@ function merge_element_heuristic(
   elseif (mem_linear_operator_elements > max_authorised_mem) && (name ∈ [:plbfgs, :plse, :plsr1])
     @warn "mem usage to important, reduction to an unstructured structure"
     N = 1
-    vec_element_function = [expr_tree]
+    vec_element_function = [expr_tree]    
     element_variables = [ExpressionTreeForge.get_elemental_variables(expr_tree)]
   end
   return (vec_element_function, element_variables, N)
@@ -242,7 +244,6 @@ function partitioned_structure(
   # Cast the constant of the complete trees
   vec_typed_complete_element_tree =
     map(tree -> ExpressionTreeForge.cast_type_of_constant(tree, type), vec_elt_complete_expr_tree)
-
   ExpressionTreeForge.set_bounds!.(vec_typed_complete_element_tree) # Propagate the bounds 
   ExpressionTreeForge.set_convexity!.(vec_typed_complete_element_tree) # deduce the convexity status 
 

--- a/test/pqnnlp.jl
+++ b/test/pqnnlp.jl
@@ -99,3 +99,13 @@ end
   plsr1nlp = PLSR1NLPModel(adnlp)
   plsenlp = PLSENLPModel(adnlp)
 end
+
+
+@testset "Methods after merging + x[1] may not appear in the expression tree" begin
+  n = 10
+  nlp = ADNLPProblems.arglinc(; n)
+  psr1nlp = PSR1NLPModel(nlp)
+
+  @test NLPModels.obj(nlp, nlp.meta.x0) == NLPModels.obj(psr1nlp, psr1nlp.meta.x0)
+  @test NLPModels.grad(nlp, nlp.meta.x0) == Vector(NLPModels.grad(psr1nlp, psr1nlp.meta.x0))
+end


### PR DESCRIPTION
Corner case: `f` merge every element and doesn't use every variable, ex: 

$$
f(x) = (\sum_{i=2}^n x_i)^2
$$ 

(e.g. $x_1$ not used).
There was an error related to the element gradient tape which require a Vector of size $n$ to evaluate and store $\frac{\partial f}{\partial x_n}$ since $x_n$ appears in $f$, while the element gradient was stored with a element vector of size $n-1$.