### PR TITLE
v0.3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PartiallySeparableNLPModels"
 uuid = "7f79d04d-aed5-44bf-a878-92b5ccf934e0"
 authors = ["raynaudp "]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"


### PR DESCRIPTION
@tmigot I implemented the partitioned backends in #97, but I didn't change the API of the module.
So I marked it at version 0.3.5 (0.3.4+1) even if the module went through big changes.
Let me know if you think it justifies v0.4.0. 